### PR TITLE
Add Trip scaffold to API

### DIFF
--- a/backend/lib/bucoliq/repo.ex
+++ b/backend/lib/bucoliq/repo.ex
@@ -2,4 +2,6 @@ defmodule Bucoliq.Repo do
   use Ecto.Repo,
     otp_app: :bucoliq,
     adapter: Ecto.Adapters.Postgres
+
+  use Scrivener, page_size: 10
 end

--- a/backend/lib/bucoliq/trip.ex
+++ b/backend/lib/bucoliq/trip.ex
@@ -1,0 +1,25 @@
+defmodule Bucoliq.Trip do
+  @moduledoc """
+  A Trip is a single outing that happens at a single point in time and
+  has many points of interest in it.  This object will be the beginning of all
+  adventures planned using Bucoliq.
+  """
+  use Ecto.Schema
+  import Ecto.Changeset
+
+  schema "trips" do
+    field :description, :string
+    field :end_time, :utc_datetime
+    field :name, :string
+    field :start_time, :utc_datetime
+
+    timestamps()
+  end
+
+  @doc false
+  def changeset(trip, attrs) do
+    trip
+    |> cast(attrs, [:name, :start_time, :end_time, :description])
+    |> validate_required([:name, :start_time, :end_time])
+  end
+end

--- a/backend/lib/bucoliq_web/controllers/trip_controller.ex
+++ b/backend/lib/bucoliq_web/controllers/trip_controller.ex
@@ -1,0 +1,52 @@
+defmodule BucoliqWeb.TripController do
+  use BucoliqWeb, :controller
+
+  def index(conn, params) do
+    page = Bucoliq.Trip |> Bucoliq.Repo.paginate(params)
+    render(conn, "index.json", %{page: page})
+  end
+
+  def show(conn, %{"id" => id}) do
+    render(conn, "show.json", %{trip: Bucoliq.Trip |> Bucoliq.Repo.get(id)})
+  end
+
+  def create(conn, params) do
+    trip_changeset = Bucoliq.Trip.changeset(%Bucoliq.Trip{}, Map.get(params, "trip"))
+
+    case Bucoliq.Repo.insert(trip_changeset) do
+      {:ok, trip} -> conn |> put_status(201) |> render("show.json", %{trip: trip})
+      {:error, changeset} -> conn |> put_status(422) |> json(%{errors: format_errors(changeset)})
+      _ -> conn |> put_status(500) |> json(%{errors: [:internal_server_error]})
+    end
+  end
+
+  def update(conn, params) do
+    trip_attributes = Map.get(params, "trip")
+    trip = Bucoliq.Trip |> Bucoliq.Repo.get(Map.get(params, "id"))
+    changeset = Bucoliq.Trip.changeset(trip, trip_attributes)
+
+    case Bucoliq.Repo.update(changeset) do
+      {:ok, trip} -> conn |> put_status(200) |> render("show.json", %{trip: trip})
+      {:error, changeset} -> conn |> put_status(422) |> json(%{errors: format_errors(changeset)})
+      _ -> conn |> put_status(500) |> json(%{errors: [:internal_server_error]})
+    end
+  end
+
+  def delete(conn, %{"id" => id}) do
+    trip = Bucoliq.Trip |> Bucoliq.Repo.get(id)
+
+    case Bucoliq.Repo.delete(trip) do
+      {:ok, trip} -> conn |> put_status(200) |> render("show.json", %{trip: trip})
+      {:error, changeset} -> conn |> put_status(422) |> json(%{errors: format_errors(changeset)})
+      _ -> conn |> put_status(500) |> json(%{errors: [:internal_server_error]})
+    end
+  end
+
+  defp format_errors(changeset) do
+    Ecto.Changeset.traverse_errors(changeset, fn {msg, opts} ->
+      Enum.reduce(opts, msg, fn {key, value}, acc ->
+        String.replace(acc, "%{#{key}}", to_string(value))
+      end)
+    end)
+  end
+end

--- a/backend/lib/bucoliq_web/router.ex
+++ b/backend/lib/bucoliq_web/router.ex
@@ -23,5 +23,6 @@ defmodule BucoliqWeb.Router do
     pipe_through :api
 
     get "/status", StatusController, :index
+    resources "/trips", TripController, except: [:new, :edit]
   end
 end

--- a/backend/lib/bucoliq_web/views/trip_view.ex
+++ b/backend/lib/bucoliq_web/views/trip_view.ex
@@ -1,0 +1,27 @@
+defmodule BucoliqWeb.TripView do
+  use BucoliqWeb, :view
+
+  def render("index.json", %{page: page}) do
+    %{
+      trips: render_many(page.entries, BucoliqWeb.TripView, "trip.json"),
+      page_number: page.page_number,
+      page_size: page.page_size,
+      total_pages: page.total_pages,
+      total_entries: page.total_entries
+    }
+  end
+
+  def render("show.json", %{trip: trip}) do
+    %{trip: render_one(trip, BucoliqWeb.TripView, "trip.json")}
+  end
+
+  def render("trip.json", %{trip: trip}) do
+    %{
+      id: trip.id,
+      name: trip.name,
+      start_time: trip.start_time,
+      end_time: trip.end_time,
+      description: trip.description
+    }
+  end
+end

--- a/backend/mix.exs
+++ b/backend/mix.exs
@@ -20,7 +20,7 @@ defmodule Bucoliq.MixProject do
   def application do
     [
       mod: {Bucoliq.Application, []},
-      extra_applications: [:logger, :runtime_tools]
+      extra_applications: [:logger, :runtime_tools, :scrivener_ecto]
     ]
   end
 
@@ -42,7 +42,8 @@ defmodule Bucoliq.MixProject do
       {:phoenix_live_reload, "~> 1.2", only: :dev},
       {:gettext, "~> 0.11"},
       {:jason, "~> 1.0"},
-      {:plug_cowboy, "~> 2.0"}
+      {:plug_cowboy, "~> 2.0"},
+      {:scrivener_ecto, "~> 2.0"}
     ]
   end
 

--- a/backend/mix.lock
+++ b/backend/mix.lock
@@ -20,5 +20,7 @@
   "plug_crypto": {:hex, :plug_crypto, "1.0.0", "18e49317d3fa343f24620ed22795ec29d4a5e602d52d1513ccea0b07d8ea7d4d", [:mix], [], "hexpm"},
   "postgrex": {:hex, :postgrex, "0.15.1", "23ce3417de70f4c0e9e7419ad85bdabcc6860a6925fe2c6f3b1b5b1e8e47bf2f", [:mix], [{:connection, "~> 1.0", [hex: :connection, repo: "hexpm", optional: false]}, {:db_connection, "~> 2.1", [hex: :db_connection, repo: "hexpm", optional: false]}, {:decimal, "~> 1.5", [hex: :decimal, repo: "hexpm", optional: false]}, {:jason, "~> 1.0", [hex: :jason, repo: "hexpm", optional: true]}], "hexpm"},
   "ranch": {:hex, :ranch, "1.7.1", "6b1fab51b49196860b733a49c07604465a47bdb78aa10c1c16a3d199f7f8c881", [:rebar3], [], "hexpm"},
+  "scrivener": {:hex, :scrivener, "2.7.0", "fa94cdea21fad0649921d8066b1833d18d296217bfdf4a5389a2f45ee857b773", [:mix], [], "hexpm"},
+  "scrivener_ecto": {:hex, :scrivener_ecto, "2.2.0", "53d5f1ba28f35f17891cf526ee102f8f225b7024d1cdaf8984875467158c9c5e", [:mix], [{:ecto, "~> 3.0", [hex: :ecto, repo: "hexpm", optional: false]}, {:scrivener, "~> 2.4", [hex: :scrivener, repo: "hexpm", optional: false]}], "hexpm"},
   "telemetry": {:hex, :telemetry, "0.4.1", "ae2718484892448a24470e6aa341bc847c3277bfb8d4e9289f7474d752c09c7f", [:rebar3], [], "hexpm"},
 }

--- a/backend/priv/repo/migrations/20191201221702_create_trips.exs
+++ b/backend/priv/repo/migrations/20191201221702_create_trips.exs
@@ -1,0 +1,15 @@
+defmodule Bucoliq.Repo.Migrations.CreateTrips do
+  use Ecto.Migration
+
+  def change do
+    create table(:trips) do
+      add :name, :string, null: false
+      add :start_time, :utc_datetime, null: false
+      add :end_time, :utc_datetime, null: false
+      add :description, :text
+
+      timestamps()
+    end
+
+  end
+end

--- a/backend/test/bucoliq_web/controllers/trip_controller_test.exs
+++ b/backend/test/bucoliq_web/controllers/trip_controller_test.exs
@@ -1,0 +1,116 @@
+defmodule BucoliqWeb.TripControllerTest do
+  use BucoliqWeb.ConnCase
+
+  test "GET /api/trips", %{conn: conn} do
+    conn = get(conn, "/api/trips")
+    assert %{"trips" => []} = json_response(conn, 200)
+
+    create_trip()
+    conn = get(conn, "/api/trips")
+
+    assert %{
+             "trips" => [
+               %{
+                 "name" => "test",
+                 "start_time" => "2019-01-01T00:00:00Z",
+                 "end_time" => "2019-01-01T00:00:00Z",
+                 "description" => nil
+               }
+             ]
+           } = json_response(conn, 200)
+  end
+
+  test "GET /api/trips/:id", %{conn: conn} do
+    {:ok, trip} = create_trip()
+    conn = get(conn, "/api/trips/#{trip.id}")
+
+    assert %{
+             "trip" => %{
+               "name" => "test",
+               "start_time" => "2019-01-01T00:00:00Z",
+               "end_time" => "2019-01-01T00:00:00Z",
+               "description" => nil
+             }
+           } = json_response(conn, 200)
+  end
+
+  test "POST /api/trips", %{conn: conn} do
+    conn =
+      post(conn, "/api/trips", %{
+        "trip" => %{
+          "name" => "test",
+          "start_time" => "2019-01-01T00:00:00Z",
+          "end_time" => "2019-01-01T00:00:00Z",
+          "description" => nil
+        }
+      })
+
+    assert %{
+             "trip" => %{
+               "id" => id,
+               "name" => "test",
+               "start_time" => "2019-01-01T00:00:00Z",
+               "end_time" => "2019-01-01T00:00:00Z",
+               "description" => nil
+             }
+           } = json_response(conn, 201)
+
+    assert id != nil
+  end
+
+  test "PUT /api/trips/:id", %{conn: conn} do
+    {:ok, trip} = create_trip()
+
+    conn =
+      put(conn, "/api/trips/#{trip.id}", %{
+        "trip" => %{
+          "name" => "testing",
+          "start_time" => "2019-01-01T00:00:00Z",
+          "end_time" => "2019-01-01T00:00:01Z",
+          "description" => "hey, big man, let me hold a dollar."
+        }
+      })
+
+    assert %{
+             "trip" => %{
+               "id" => id,
+               "name" => "testing",
+               "start_time" => "2019-01-01T00:00:00Z",
+               "end_time" => "2019-01-01T00:00:01Z",
+               "description" => "hey, big man, let me hold a dollar."
+             }
+           } = json_response(conn, 200)
+  end
+
+  test "DELETE /api/trips/:id", %{conn: conn} do
+    {:ok, trip} = create_trip()
+
+    conn = delete(conn, "/api/trips/#{trip.id}")
+
+    assert %{
+             "trip" => %{
+               "id" => id,
+               "name" => "test",
+               "start_time" => "2019-01-01T00:00:00Z",
+               "end_time" => "2019-01-01T00:00:00Z",
+               "description" => nil
+             }
+           } = json_response(conn, 200)
+
+    assert Bucoliq.Repo.aggregate(Bucoliq.Trip, :count, :id) == 0
+  end
+
+  defp create_trip do
+    {:ok, start_time, _} = DateTime.from_iso8601("2019-01-01T00:00:00Z")
+    {:ok, end_time, _} = DateTime.from_iso8601("2019-01-01T00:00:00Z")
+
+    trip = %Bucoliq.Trip{
+      name: "test",
+      start_time: start_time,
+      end_time: end_time
+    }
+
+    trip_changeset = Bucoliq.Trip.changeset(trip, %{})
+    Bucoliq.Repo.insert(trip_changeset)
+  end
+end


### PR DESCRIPTION
This changeset enables full CRUD for Trip objects with minimal
validation thereof.

Resolves #1